### PR TITLE
コントロールセンターからシークすると必ず再生の最初に戻るバグ修正

### DIFF
--- a/darwin/Classes/NotificationsHandler.swift
+++ b/darwin/Classes/NotificationsHandler.swift
@@ -325,7 +325,7 @@ class NotificationsHandler {
         
         let positionTime = (changePositionEvent as! MPChangePlaybackPositionCommandEvent).positionTime
         log("changePlaybackPosition to %f", positionTime)
-        let newTime = toCMTime(millis: positionTime)
+        let newTime = CMTimeMakeWithSeconds(positionTime, preferredTimescale: Int32(NSEC_PER_SEC))
         player.seek(time: newTime)
         return MPRemoteCommandHandlerStatus.success
     }

--- a/darwin/Classes/NotificationsHandler.swift
+++ b/darwin/Classes/NotificationsHandler.swift
@@ -325,7 +325,7 @@ class NotificationsHandler {
         
         let positionTime = (changePositionEvent as! MPChangePlaybackPositionCommandEvent).positionTime
         log("changePlaybackPosition to %f", positionTime)
-        let newTime = CMTimeMakeWithSeconds(positionTime, preferredTimescale: Int32(NSEC_PER_SEC))
+        let newTime = toCMTime(sec: positionTime)
         player.seek(time: newTime)
         return MPRemoteCommandHandlerStatus.success
     }

--- a/darwin/Classes/Utils.swift
+++ b/darwin/Classes/Utils.swift
@@ -16,8 +16,16 @@ func toCMTime(millis: Int) -> CMTime {
     return toCMTime(millis: Float(millis))
 }
 
+func toCMTime(sec: Double) -> CMTime {
+    return toCMTime(sec: Float(sec))
+}
+
 func toCMTime(millis: Double) -> CMTime {
     return toCMTime(millis: Float(millis))
+}
+
+func toCMTime(sec: Float) -> CMTime {
+    return CMTimeMakeWithSeconds(Float64(sec), preferredTimescale: Int32(NSEC_PER_SEC))
 }
 
 func toCMTime(millis: Float) -> CMTime {

--- a/darwin/Classes/WrappedMediaPlayer.swift
+++ b/darwin/Classes/WrappedMediaPlayer.swift
@@ -140,7 +140,7 @@ class WrappedMediaPlayer {
             log("Cannot skip forward, unable to determine maxDuration")
             return
         }
-        let newTime = CMTimeAdd(currentTime, toCMTime(millis: interval))
+        let newTime = CMTimeAdd(currentTime, toCMTime(sec: interval))
         
         // if CMTime is more than max duration, limit it
         let clampedTime = CMTimeGetSeconds(newTime) > CMTimeGetSeconds(maxDuration) ? maxDuration : newTime
@@ -153,7 +153,7 @@ class WrappedMediaPlayer {
             return
         }
         
-        let newTime = CMTimeSubtract(currentTime, toCMTime(millis: interval))
+        let newTime = CMTimeSubtract(currentTime, toCMTime(sec: interval))
         // if CMTime is negative, set it to zero
         let clampedTime = CMTimeGetSeconds(newTime) < 0 ? toCMTime(millis: 0) : newTime
         


### PR DESCRIPTION
`positionTime` が秒の単位で来ているのを  `toCMTime(millis: positionTime)` でミリ秒に変えているせいで発生していた。

本家もバグってるっぽい。。