### PR TITLE
bufferSeconds のパラメータ追加

### DIFF
--- a/darwin/Classes/SwiftAudioplayersPlugin.swift
+++ b/darwin/Classes/SwiftAudioplayersPlugin.swift
@@ -22,6 +22,8 @@ let AudioplayersPluginStop = NSNotification.Name("AudioplayersPluginStop")
 
 public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
     
+    private static let defaultBufferSeconds = 15
+    
     var registrar: FlutterPluginRegistrar
     var channel: FlutterMethodChannel
     var notificationsHandler: NotificationsHandler? = nil
@@ -126,6 +128,7 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
             
             let isLocal: Bool = (args["isLocal"] as? Bool) ?? true
             let volume: Float = (args["volume"] as? Float) ?? 1.0
+            let bufferSeconds: Int = (args["bufferSeconds"] as? Int) ?? Self.defaultBufferSeconds
             
             // we might or might not want to seek
             let seekTimeMillis: Int? = (args["position"] as? Int)
@@ -140,7 +143,8 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
                 volume: volume,
                 time: seekTime,
                 isNotification: respectSilence,
-                recordingActive: recordingActive
+                recordingActive: recordingActive,
+                bufferSeconds: bufferSeconds
             )
         } else if method == "pause" {
             player.pause()
@@ -164,6 +168,7 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
             let isLocal: Bool = (args["isLocal"] as? Bool) ?? false
             let respectSilence: Bool = (args["respectSilence"] as? Bool) ?? false
             let recordingActive: Bool = (args["recordingActive"] as? Bool) ?? false
+            let bufferSeconds: Int = (args["bufferSeconds"] as? Int) ?? Self.defaultBufferSeconds
             
             if url == nil {
                 log("Null URL received on setUrl")
@@ -175,7 +180,8 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
                 url: url!,
                 isLocal: isLocal,
                 isNotification: respectSilence,
-                recordingActive: recordingActive
+                recordingActive: recordingActive,
+                bufferSeconds: bufferSeconds
             ) {
                 player in
                 result(1)

--- a/darwin/Classes/WrappedMediaPlayer.swift
+++ b/darwin/Classes/WrappedMediaPlayer.swift
@@ -210,6 +210,7 @@ class WrappedMediaPlayer {
         isLocal: Bool,
         isNotification: Bool,
         recordingActive: Bool,
+        bufferSeconds: Int,
         onReady: @escaping (AVPlayer) -> Void
     ) {
         reference.updateCategory(recordingActive: recordingActive, isNotification: isNotification, playingRoute: playingRoute)
@@ -219,6 +220,10 @@ class WrappedMediaPlayer {
             let parsedUrl = isLocal ? URL.init(fileURLWithPath: url) : URL.init(string: url)!
             let playerItem = AVPlayerItem.init(url: parsedUrl)
             playerItem.audioTimePitchAlgorithm = AVAudioTimePitchAlgorithm.timeDomain
+            if #available(iOS 10.0, *) {
+                playerItem.preferredForwardBufferDuration = Double(bufferSeconds)
+            }
+            
             let player: AVPlayer
             if let existingPlayer = self.player {
                 keyVakueObservation?.invalidate()
@@ -286,7 +291,8 @@ class WrappedMediaPlayer {
         volume: Float,
         time: CMTime?,
         isNotification: Bool,
-        recordingActive: Bool
+        recordingActive: Bool,
+        bufferSeconds: Int
     ) {
         reference.updateCategory(recordingActive: recordingActive, isNotification: isNotification, playingRoute: playingRoute)
         
@@ -294,7 +300,8 @@ class WrappedMediaPlayer {
             url: url,
             isLocal: isLocal,
             isNotification: isNotification,
-            recordingActive: recordingActive
+            recordingActive: recordingActive,
+            bufferSeconds: bufferSeconds
         ) {
             player in
             player.volume = volume

--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -395,6 +395,7 @@ class AudioPlayer {
     bool stayAwake = false,
     bool duckAudio = false,
     bool recordingActive = false,
+    int bufferSeconds,
   }) async {
     isLocal ??= isLocalUrl(url);
     volume ??= 1.0;
@@ -410,6 +411,7 @@ class AudioPlayer {
       'stayAwake': stayAwake ?? false,
       'duckAudio': duckAudio ?? false,
       'recordingActive': recordingActive ?? false,
+      'bufferSeconds': bufferSeconds,
     });
 
     if (result == 1) {


### PR DESCRIPTION
`preferredForwardBufferDuration` へ値を渡すために `bufferSeconds` というパラメータを追加しました。

## 関連

https://github.com/gnus-inc/radiko-app/pull/374

## 参考

https://developer.apple.com/documentation/avfoundation/avplayeritem/1643630-preferredforwardbufferduration