### PR TITLE
fix: setNotification:elapsedTime is in msec on swift side

### DIFF
--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -572,7 +572,7 @@ class AudioPlayer {
       'forwardSkipInterval': forwardSkipInterval.inSeconds,
       'backwardSkipInterval': backwardSkipInterval.inSeconds,
       'duration': duration.inSeconds,
-      'elapsedTime': elapsedTime.inSeconds,
+      'elapsedTime': elapsedTime.inMilliseconds,
       'hasPreviousTrack': hasPreviousTrack,
       'hasNextTrack': hasNextTrack
     });


### PR DESCRIPTION
It seems that `AudioPlayer.setNotification`'s `elapsedTime` param should be in milli seconds instead of seconds, while the Swift side implementation looks as below (and it's reasonable):
https://github.com/gnus-inc/audioplayers/blob/master/darwin/Classes/NotificationsHandler.swift#L218
```swift
        reference.updateNotifications(player: reference.lastPlayer()!, time: toCMTime(millis: elapsedTime))
```