### PR TITLE
fix: make live streaming playback starts from beginning of buffer

### DIFF
--- a/darwin/Classes/SwiftAudioplayersPlugin.swift
+++ b/darwin/Classes/SwiftAudioplayersPlugin.swift
@@ -170,6 +170,9 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
             let recordingActive: Bool = (args["recordingActive"] as? Bool) ?? false
             let bufferSeconds: Int = (args["bufferSeconds"] as? Int) ?? Self.defaultBufferSeconds
             
+            let seekTimeMillis: Int? = (args["position"] as? Int)
+            let seekTime: CMTime? = seekTimeMillis.map { toCMTime(millis: $0) }
+
             if url == nil {
                 log("Null URL received on setUrl")
                 result(0)
@@ -181,6 +184,7 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
                 isLocal: isLocal,
                 isNotification: respectSilence,
                 recordingActive: recordingActive,
+                time: seekTime,
                 bufferSeconds: bufferSeconds
             ) {
                 player in

--- a/darwin/Classes/WrappedMediaPlayer.swift
+++ b/darwin/Classes/WrappedMediaPlayer.swift
@@ -210,6 +210,7 @@ class WrappedMediaPlayer {
         isLocal: Bool,
         isNotification: Bool,
         recordingActive: Bool,
+        time: CMTime?,
         bufferSeconds: Int,
         onReady: @escaping (AVPlayer) -> Void
     ) {
@@ -223,7 +224,13 @@ class WrappedMediaPlayer {
             if #available(iOS 10.0, *) {
                 playerItem.preferredForwardBufferDuration = Double(bufferSeconds)
             }
-            
+
+            if let time = time {
+                playerItem.seek(to: time)
+            } else {
+                playerItem.seek(to: CMTime.zero)
+            }
+
             let player: AVPlayer
             if let existingPlayer = self.player {
                 keyVakueObservation?.invalidate()
@@ -280,6 +287,11 @@ class WrappedMediaPlayer {
             keyVakueObservation = newKeyValueObservation
         } else {
             if playbackStatus == .readyToPlay {
+                if let time = time {
+                    player!.seek(to: time)
+                } else {
+                    player!.seek(to: CMTime.zero)
+                }
                 onReady(player!)
             }
         }
@@ -301,13 +313,11 @@ class WrappedMediaPlayer {
             isLocal: isLocal,
             isNotification: isNotification,
             recordingActive: recordingActive,
+            time: time,
             bufferSeconds: bufferSeconds
         ) {
             player in
             player.volume = volume
-            if let time = time {
-                player.seek(to: time)
-            }
             self.resume()
         }
         


### PR DESCRIPTION
With an HC AAC live streaming asset, the player starts at almost
the tail of the buffer. It seems this behavior comes to enable
seeking. For instance, say we have an asset with 3:00 duration,
the player starts playback from 2:45.

For most of the use cases this is bad for UX since:
- playback doesn't start where the user wanted.
- The player often stops playing due to suffering prefetched data.
  (It's seen 15 seconds only)