### PR TITLE
Fix/live streaming start from beginning

### DIFF
--- a/darwin/Classes/SwiftAudioplayersPlugin.swift
+++ b/darwin/Classes/SwiftAudioplayersPlugin.swift
@@ -170,6 +170,9 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
             let recordingActive: Bool = (args["recordingActive"] as? Bool) ?? false
             let bufferSeconds: Int = (args["bufferSeconds"] as? Int) ?? Self.defaultBufferSeconds
             
+            let seekTimeMillis: Int? = (args["position"] as? Int)
+            let seekTime: CMTime? = seekTimeMillis.map { toCMTime(millis: $0) }
+
             if url == nil {
                 log("Null URL received on setUrl")
                 result(0)
@@ -181,6 +184,7 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
                 isLocal: isLocal,
                 isNotification: respectSilence,
                 recordingActive: recordingActive,
+                time: seekTime,
                 bufferSeconds: bufferSeconds
             ) {
                 player in

--- a/darwin/Classes/WrappedMediaPlayer.swift
+++ b/darwin/Classes/WrappedMediaPlayer.swift
@@ -319,6 +319,11 @@ class WrappedMediaPlayer {
             keyVakueObservation = newKeyValueObservation
         } else {
             if playbackStatus == .readyToPlay {
+                if let time = time {
+                    player!.seek(to: time)
+                } else {
+                    player!.seek(to: CMTime.zero)
+                }
                 onReady(player!)
             }
         }

--- a/darwin/Classes/WrappedMediaPlayer.swift
+++ b/darwin/Classes/WrappedMediaPlayer.swift
@@ -210,6 +210,7 @@ class WrappedMediaPlayer {
         isLocal: Bool,
         isNotification: Bool,
         recordingActive: Bool,
+        time: CMTime?,
         bufferSeconds: Int,
         onReady: @escaping (AVPlayer) -> Void
     ) {
@@ -223,7 +224,13 @@ class WrappedMediaPlayer {
             if #available(iOS 10.0, *) {
                 playerItem.preferredForwardBufferDuration = Double(bufferSeconds)
             }
-            
+
+            if let time = time {
+                playerItem.seek(to: time)
+            } else {
+                playerItem.seek(to: CMTime.zero)
+            }
+
             let player: AVPlayer
             if let existingPlayer = self.player {
                 keyVakueObservation?.invalidate()
@@ -280,6 +287,11 @@ class WrappedMediaPlayer {
             keyVakueObservation = newKeyValueObservation
         } else {
             if playbackStatus == .readyToPlay {
+                if let time = time {
+                    player!.seek(to: time)
+                } else {
+                    player!.seek(to: CMTime.zero)
+                }
                 onReady(player!)
             }
         }
@@ -301,13 +313,11 @@ class WrappedMediaPlayer {
             isLocal: isLocal,
             isNotification: isNotification,
             recordingActive: recordingActive,
+            time: time,
             bufferSeconds: bufferSeconds
         ) {
             player in
             player.volume = volume
-            if let time = time {
-                player.seek(to: time)
-            }
             self.resume()
         }
         

--- a/darwin/Classes/WrappedMediaPlayer.swift
+++ b/darwin/Classes/WrappedMediaPlayer.swift
@@ -206,7 +206,7 @@ class WrappedMediaPlayer {
     func achieveInitialSeek(_ time: CMTime) {
         guard let initialSeek = initialSeek else { return }
         if abs(time.seconds - initialSeek.seconds) < 20 {
-            // Confirm only when it has fulfilled for 1 seconds.
+            // Confirm only when it has fulfilled for 1 second.
             initialSeekFulfill += 1
             if (5 <= initialSeekFulfill) {
                 self.initialSeek = nil

--- a/darwin/Classes/WrappedMediaPlayer.swift
+++ b/darwin/Classes/WrappedMediaPlayer.swift
@@ -12,7 +12,6 @@ class WrappedMediaPlayer {
     
     var observers: [TimeObserver]
     var keyVakueObservation: NSKeyValueObservation?
-    var bufferingObservation: NSKeyValueObservation?
 
     var isPlaying: Bool
     var playbackRate: Float
@@ -22,6 +21,7 @@ class WrappedMediaPlayer {
     var url: String?
     var onReady: ((AVPlayer) -> Void)?
     var initialSeek: CMTime?
+    var initialSeekFulfill: Int
     var initialSeekSentinel: Int
 
     init(
@@ -51,6 +51,7 @@ class WrappedMediaPlayer {
         self.looping = looping
         self.url = url
         self.onReady = onReady
+        self.initialSeekFulfill = 0
         self.initialSeekSentinel = 0
     }
     
@@ -204,12 +205,16 @@ class WrappedMediaPlayer {
 
     func achieveInitialSeek(_ time: CMTime) {
         guard let initialSeek = initialSeek else { return }
-
         if abs(time.seconds - initialSeek.seconds) < 20 {
-            self.initialSeek = nil
+            // Confirm only when it has fulfilled for 1 seconds.
+            initialSeekFulfill += 1
+            if (5 <= initialSeekFulfill) {
+                self.initialSeek = nil
+            }
             return
         }
 
+        initialSeekFulfill = 0
         player?.seek(to: initialSeek)
 
         initialSeekSentinel -= 1
@@ -248,6 +253,15 @@ class WrappedMediaPlayer {
             if #available(iOS 10.0, *) {
                 playerItem.preferredForwardBufferDuration = Double(bufferSeconds)
             }
+
+            initialSeekFulfill = 0
+            initialSeekSentinel = 3000 / 200 // 3sec / timeObserver's interval
+            if let time = time {
+                initialSeek = time
+            } else {
+                initialSeek = CMTime.zero
+            }
+            playerItem.seek(to: initialSeek!)
 
             let player: AVPlayer
             if let existingPlayer = self.player {
@@ -303,29 +317,8 @@ class WrappedMediaPlayer {
             
             keyVakueObservation?.invalidate()
             keyVakueObservation = newKeyValueObservation
-
-          if let time = time {
-              initialSeek = time
-          } else {
-              initialSeek = CMTime.zero
-          }
-          initialSeekSentinel = 3000 / 200 // 3sec / timeObserver's interval
-
-          bufferingObservation?.invalidate()
-          bufferingObservation = playerItem.observe(\AVPlayerItem.isPlaybackLikelyToKeepUp) { [weak self] (playerItem, change) in
-              if playerItem.isPlaybackLikelyToKeepUp {
-                  if let initialSeek = self?.initialSeek {
-                      self!.player!.seek(to: initialSeek)
-                  }
-              }
-          }
         } else {
             if playbackStatus == .readyToPlay {
-                if let time = time {
-                    player!.seek(to: time)
-                } else {
-                    player!.seek(to: CMTime.zero)
-                }
                 onReady(player!)
             }
         }


### PR DESCRIPTION
fix: to ensure the initial seek, it needed a more heuristic method.

Now to achieve it, the result pos must fulfill for 1 second in a row.